### PR TITLE
Added transit tuning function, readded tle and qth functions

### DIFF
--- a/predict.c
+++ b/predict.c
@@ -3478,7 +3478,7 @@ static PyObject* quick_predict(PyObject* self, PyObject *args)
 	//TODO: Seems like this should be based on the freshness of the TLE, not wall clock.
 	if ((daynum<now-365.0) || (daynum>now+365.0))
 	{
-		sprintf(errbuff, "calculation date invalid: |calc - now| < 365 (%f)\n", daynum-now);
+		sprintf(errbuff, "time %s too far from present\n", Daynum2String(daynum));
 		PyErr_SetString(PredictException, errbuff);
 		goto cleanup_and_raise_exception;
 	}

--- a/predict.py
+++ b/predict.py
@@ -112,7 +112,7 @@ class Transit():
         return self.prune(lambda ts: self.at(ts)['elevation'] >= elevation)
 
     # Return section of a transit where a pruning function is valid.
-    # Currently used to set elevation threshold, could also be used for site-specific horizon masks.
+    # Currently used to set elevation threshold, unclear what other uses it might have.
     # fx must either return false everywhere or true for a contiguous period including the peak
     def prune(self, fx, epsilon=0.1):
         peak = self.peak()['epoch']


### PR DESCRIPTION
- prune() trims edges of transit according to trim function
- above() leverages prune() to give transit above elevation threshold (legal requirement)
- premature removal of tle() and host_qth() - too baked into infrastructure to remove yet
- minor error message improvements and cleanup

@mconst-nanosatisfi or @ttrutna 
