### PR TITLE
Add license to setup.py (and by extension the PyPi package)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ setup(
     author="Jesse Trutna",
     author_email="jesse@spire.com",
     url="https://github.com/nsat/pypredict",
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
+    ],
     py_modules=['predict'],
     ext_modules=[Extension('cpredict', ['predict.c'])]
     )


### PR DESCRIPTION
Use the appropriate "License" Trove classifiers, as set in the `Classifier` field of setup.py.

Note that per distutils documentation there is no need to also set the `license` field when an appropriate option is provided in `Classifier`.