### PR TITLE
Make hashbang portable across various systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from distutils.core import setup, Extension
 setup(


### PR DESCRIPTION
Best practice is to use `/usr/bin/env <something>` rather than a direct link.

This approach invokes whatever version of `<something>` appears first in `$PATH`. Importantly, this respects the user's choice in situations like virtualenv's and allows the scripts to be run on a wider range of platforms.