### PR TITLE
Add preliminary Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+# command to install dependencies
+install:
+  - pip install .
+
+# command to run tests
+script:
+  - ./test.py

--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest, time
+import unittest, time, sys
 import predict
 from cpredict import quick_find, quick_predict, PredictException
 
@@ -40,4 +40,6 @@ if __name__ == '__main__':
 
   for test in tests:
     suite = unittest.TestLoader().loadTestsFromTestCase(test)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(-1)


### PR DESCRIPTION
This PR adds preliminary support for continuous integration, specifically via the Travis-CI platform.

[Travis-CI](https://travis-ci.org/) is a cloud-hosted continuous integration platform, with good quality GitHub integration and free for open source projects.

How to enable:
* Individual developers who forked pypredict can [enable Travis-CI](https://docs.travis-ci.com/user/getting-started/) on their own GitHub-hosted fork, via Travis-CI's GitHub integration. This allows each developer's branches to be run through CI.
* @nsat can enable Travis-CI for this upstream repo, turning on automated CI testing of all incoming PRs `<branches>` and `master` branch (with a potential status badge in `README.md`)

Comments:
* At the moment, the singular unit test fails regardless of whether run locally or on a cloud-based vendor. There are two known issues I've identified:

  - [x] ~~(**EASY**) QTH format supplied in the unit test differs from that expected by the pypredict API. (https://github.com/nsat/pypredict/pull/30)~~
  - [ ] (**MEDIUM**) Sample TLE data supplied in the unit test is treated by pypredict as too stale in 2020. There's a debug override to address this in `predict.c`, however a better solution should exist.

* Really, pypredict should move to a modern testrunner framework e.g. `pytest` and `pytest-runner`.

Neither of these two comments need to be fixed before this support lands IMHO, as they can be addressed later. In fact, having this skeleton in place provides a good base to build upon and provides confidence in future refactoring efforts.

If the testsuite is known failing at the moment, how do I know a *working* testsuite will run green? Good question. I [quickly hacked around the above two problems](https://travis-ci.org/Echelon9/pypredict/builds/332599559) which returned green on Python 2.6 and Python 2.7.

If anyone is still unconvinced of the benefits of CI, [here is a short set of reasons why](https://pantheon.io/blog/5-advantages-continuous-integration). 
