### PR TITLE
Build manylinux wheels through docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
+dist/
+wheelhouse/
 *.pyc
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ clean:
 .PHONY: manylinux-wheels
 manylinux-wheels:
 	docker run -v $(shell pwd):/io quay.io/pypa/manylinux1_x86_64:latest \
-		/io/bin/build-manylinux-wheel.sh 27 35 36 37
+		/io/bin/build-manylinux-wheel.sh 27 35 36 37 38

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONEY: help
+help:
+	@echo "Targets:"
+	@echo "  clean: Removes distribution folders and artifacts from building"
+	@echo "  manylinux-wheels: Builds binary and manylinux wheels for several python versions"
+
+.PHONY: clean
+clean:
+	rm -rf dist wheelhouse build __pycache__ *.so *.egg-info
+
+.PHONY: manylinux-wheels
+manylinux-wheels:
+	docker run -v $(shell pwd):/io quay.io/pypa/manylinux1_x86_64:latest \
+		/io/bin/build-manylinux-wheel.sh 27 35 36 37

--- a/bin/build-manylinux-wheel.sh
+++ b/bin/build-manylinux-wheel.sh
@@ -5,16 +5,18 @@ PYTHON_VERSIONS=$@
 if [[ -z "${PYTHON_VERSIONS}" ]] ; then
     echo "Usage: $(basename $0) <version>..." >&2
     echo "  A version is the two numbers in the major.minor python that you want to build" >&2
-    echo "  Example: for python 2.6 and 3.6 both" >&2
+    echo "  Example: for python 2.7 and 3.8 both" >&2
     echo "" >&2
-    echo "    $ $(basename $0) 27 36" >&2
+    echo "    $ $(basename $0) 27 38" >&2
     exit 1
 fi
 
 function get-variants() {
     local version="$1"
 
-    if [[ "${version}" = '27' ]] ; then
+    if [[ "${version}" = '38' ]] ; then
+        echo /
+    elif [[ "${version}" = '27' ]] ; then
         echo m mu
     else
         echo m
@@ -30,5 +32,5 @@ for version in ${PYTHON_VERSIONS} ; do
 done
 
 for f in dist/*.whl ; do
-    /opt/python/cp36-cp36m/bin/auditwheel repair "${f}"
+    /opt/python/cp37-cp37m/bin/auditwheel repair "${f}"
 done

--- a/bin/build-manylinux-wheel.sh
+++ b/bin/build-manylinux-wheel.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+PYTHON_VERSIONS=$@
+
+if [[ -z "${PYTHON_VERSIONS}" ]] ; then
+    echo "Usage: $(basename $0) <version>..." >&2
+    echo "  A version is the two numbers in the major.minor python that you want to build" >&2
+    echo "  Example: for python 2.6 and 3.6 both" >&2
+    echo "" >&2
+    echo "    $ $(basename $0) 27 36" >&2
+    exit 1
+fi
+
+function get-variants() {
+    local version="$1"
+
+    if [[ "${version}" = '27' ]] ; then
+        echo m mu
+    else
+        echo m
+    fi
+}
+
+cd /io
+
+for version in ${PYTHON_VERSIONS} ; do
+    for variant in $(get-variants "${version}") ; do
+        /opt/python/cp${version}-cp${version}${variant}/bin/python setup.py bdist_wheel
+    done
+done
+
+for f in dist/*.whl ; do
+    /opt/python/cp36-cp36m/bin/auditwheel repair "${f}"
+done


### PR DESCRIPTION
manylinux wheels are wheels with bundled C dependencies, to be honest
I don't think they're strictly needed for this package but doing it
with them doesn't really hurt when we're doing binary uploads anyway
since it's the most compatible version we can make.

This is an addition to PR #33 to make it easy to build and distribute binary versions of this package.