### PR TITLE
Be explicit that only Python 2 is currrently supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ sudo apt-get install python-dev
 sudo python setup.py install
 ```
 
+PyPredict currently only supports Python 2.
+
 ## Usage
 
 #### Observe a satellite (relative to a position on earth)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
     url="https://github.com/nsat/pypredict",
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
+        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: 2.7',
     ],
     py_modules=['predict'],
     ext_modules=[Extension('cpredict', ['predict.c'])]


### PR DESCRIPTION
***I am aware there are branches working on Python 3 support, but as of now the master branch only supports Python 2. Given the deprecated nature of python2 post January 2020, worthwhile to document this for users***

For user clarity, let's be clear that the only currently supported version is Python 2.

Add trove classifiers to report this to PyPi.