### PR TITLE
Guard against floating point errors in Transit at() function

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -169,7 +169,7 @@ class Transit():
     def duration(self):
         return self.end - self.start
 
-    def at(self, t):
-        if t < self.start or t > self.end:
+    def at(self, t, epsilon=0.001):
+        if t < (self.start - epsilon) or t > (self.end + epsilon):
             raise PredictException("time %f outside transit [%f, %f]" % (t, self.start, self.end))
         return observe(self.tle, self.qth, t)


### PR DESCRIPTION
Adding an epsilon to the time comparison to avoid observations using `at()` around the start and end of the transit from throwing an exception due to floating point rounding.