### PR TITLE
Improve reliability of the wheel build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ clean:
 
 .PHONY: manylinux-wheels
 manylinux-wheels:
-	docker run -v $(shell pwd):/io quay.io/pypa/manylinux1_x86_64:latest \
+	docker run --user $(shell id -u):$(shell id -g) -v $(shell pwd):/io quay.io/pypa/manylinux1_x86_64:latest \
 		/io/bin/build-manylinux-wheel.sh 27 35 36 37 38

--- a/bin/build-manylinux-wheel.sh
+++ b/bin/build-manylinux-wheel.sh
@@ -23,14 +23,15 @@ function get-variants() {
     fi
 }
 
-cd /io
+cd /io || exit
+mkdir -p wheelhouse || exit
 
 for version in ${PYTHON_VERSIONS} ; do
     for variant in $(get-variants "${version}") ; do
-        /opt/python/cp${version}-cp${version}${variant}/bin/python setup.py bdist_wheel
+        "/opt/python/cp${version}-cp${version}${variant}/bin/pip" wheel /io -w wheelhouse/
     done
 done
 
-for f in dist/*.whl ; do
-    /opt/python/cp37-cp37m/bin/auditwheel repair "${f}"
+for f in wheelhouse/*.whl ; do
+    /usr/local/bin/auditwheel repair "${f}"
 done

--- a/bin/build-manylinux-wheel.sh
+++ b/bin/build-manylinux-wheel.sh
@@ -28,7 +28,7 @@ mkdir -p wheelhouse || exit
 
 for version in ${PYTHON_VERSIONS} ; do
     for variant in $(get-variants "${version}") ; do
-        "/opt/python/cp${version}-cp${version}${variant}/bin/pip" wheel /io -w wheelhouse/
+        "/opt/python/cp${version}-cp${version}${variant}/bin/pip" --no-cache-dir wheel /io -w wheelhouse/
     done
 done
 


### PR DESCRIPTION
Small improvements to the wheel build script and makefile to avoid permission errors and manylinux docker changes from breaking builds.

- Use local user rather than root during build
- Use pip instead of python setup.py
- Use auditwheel from PATH rather than from a specific python install dir