### PR TITLE
Use README.md for long description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,17 +50,5 @@ test: install
 	pytest
 
 .PHONY: upload
-upload: build check-env
-	twine upload --repository-url ${REPO} --username ${USER} --password "${PASSWORD}" dist/*
-
-.PHONY: check-env
-check-env:
-ifndef REPO
-	$(error $REPO must be specified)
-endif
-ifndef USER
-	$(error USER must be specified)
-endif
-ifndef PASSWORD
-	$(error PASSWORD must be specified)
-endif
+upload: build
+	twine upload wheelhouse/* $(sdist)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="jesse@spire.com",
     maintainer="Spire Global Inc",
     maintainer_email="opensource@spire.com",
-    description="Python package for satellite tracking and orbital prediction",
+    description="Interface to the Predict satellite tracking and orbital prediction library",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/nsat/pypredict",

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,12 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pypredict",
-    version="1.6.2",
+    version="1.6.3",
     author="Jesse Trutna",
     author_email="jesse@spire.com",
     maintainer="Spire Global Inc",
     maintainer_email="opensource@spire.com",
+    description="Python package for satellite tracking and orbital prediction",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/nsat/pypredict",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, Extension
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 
 from setuptools import setup, Extension
 
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name="pypredict",
     version="1.6.2",
@@ -9,6 +12,8 @@ setup(
     author_email="jesse@spire.com",
     maintainer="Spire Global Inc",
     maintainer_email="opensource@spire.com",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/nsat/pypredict",
     py_modules=["predict"],
     ext_modules=[Extension("cpredict", ["predict.c"])],


### PR DESCRIPTION
Also updates the makefile to correct the files to upload using twine to use the manylinux wheels.

The REPO/USER/PASS vars have been removed and twine will now use the defaults in .pypirc if they are set, otherwise these can be overriden using twine's own environment variables when executing the make upload step: https://twine.readthedocs.io/en/latest/#environment-variables