### PR TITLE
Add Python 3.10 and 3.11 support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Check style with `black`
         uses: psf/black@stable
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.7", "3.8", "3.9"]
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ wheels := \
 	dist/$(NAME)-$(VERSION)-cp27-cp27mu-$(ARCH).whl \
 	dist/$(NAME)-$(VERSION)-cp37-cp37m-$(ARCH).whl \
 	dist/$(NAME)-$(VERSION)-cp38-cp38-$(ARCH).whl \
-	dist/$(NAME)-$(VERSION)-cp39-cp39-$(ARCH).whl
-
--include .makerc
+	dist/$(NAME)-$(VERSION)-cp39-cp39-$(ARCH).whl \
+	dist/$(NAME)-$(VERSION)-cp310-cp310-$(ARCH).whl \
+	dist/$(NAME)-$(VERSION)-cp311-cp311-$(ARCH).whl
 
 .PHONY: help
 help:
@@ -30,10 +30,13 @@ build: sdist manylinux-wheels
 .PHONY: manylinux-wheels
 manylinux-wheels: $(wheels)
 
-$(wheels) &: $(src)
+$(wheels): $(src)
 	docker run --user $(shell id -u):$(shell id -g) -v $(shell pwd):/io \
 		quay.io/pypa/manylinux1_x86_64:latest \
-		/io/bin/build-manylinux-wheel.sh 27 37 38 39
+		/io/bin/build-manylinux-wheel.sh 27
+	docker run --user $(shell id -u):$(shell id -g) -v $(shell pwd):/io \
+		quay.io/pypa/manylinux_2_28_x86_64:latest \
+		/io/bin/build-manylinux-wheel.sh 37 38 39 310 311
 
 .PHONY: sdist
 sdist: $(sdist)

--- a/bin/build-manylinux-wheel.sh
+++ b/bin/build-manylinux-wheel.sh
@@ -18,7 +18,7 @@ fi
 function get-variants() {
     local version="$1"
 
-    if [[ "${version}" = '38' || "${version}" = '39' ]] ; then
+    if [[ "${version}" = '38' || "${version}" = '39' || "${version}" = '310' || "${version}" = '311' ]] ; then
         echo /
     elif [[ "${version}" = '27' ]] ; then
         echo m mu
@@ -34,8 +34,6 @@ for version in ${PYTHON_VERSIONS} ; do
     for variant in $(get-variants "${version}") ; do
         "/opt/python/cp${version}-cp${version}${variant}/bin/pip" --no-cache-dir wheel /io -w dist/
     done
-done
 
-for f in dist/*.whl ; do
-    /usr/local/bin/auditwheel repair "${f}"
+    /usr/local/bin/auditwheel repair dist/*cp${version}-cp*
 done

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pypredict",
-    version="1.7.0",
+    version="1.7.1",
     author="Jesse Trutna",
     author_email="jesse@spire.com",
     maintainer="Spire Global Inc",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py38,py39
+envlist = py27,py38,py39,py310,py311
 
 [testenv]
 deps = pytest
@@ -13,3 +13,5 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311


### PR DESCRIPTION
This also updates the manylinux base for all python3 versions to a newer (supported) release.

Tested in Python 3.11:
```
root@ed0fd0434619:/pypredict# python3
Python 3.11.4 (main, Jul 28 2023, 05:02:22) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import predict
>>> tle='''0 LEMUR 1
... 1 40044U 14033AL  23221.74491137  .00002349  00000-0  33527-3 0  9990
... 2 40044  97.6724  33.3927 0055349 242.1156 117.4442 14.76595710491566
... '''
>>> qth=(0,0,0)
>>> import time
>>> predict.quick_predict(tle=tle, qth=qth, ts=time.time())[0]
{'norad_id': 40044, 'name': '0 LEMUR 1', 'epoch': 1691726231.9165578, 'latitude': -17.13144263315735, 'longitude': 18.44200581459458, 'azimuth': 134.08233213751, 'elevation': 0.024514276043866044, 'orbital_velocity': 27081.368214171, 'footprint': 5556.775550153253, 'altitude': 656.9883901810581, 'slant_range': 2961.4649877898605, 'eclipse_depth': -8.078600804508218, 'orbital_phase': 74.52818693865964, 'orbital_model': 'SGP4', 'visibility': b'V', 'sunlit': 1, 'orbit': 49177, 'geostationary': 0, 'has_aos': 1, 'decayed': 0, 'doppler': 1832.236825634777, 'eci_x': 5362.917004655394, 'eci_y': 4057.277134434491, 'eci_z': -2060.265299041267, 'eci_vx': 2.3998370520358243, 'eci_vy': 0.4991610080967417, 'eci_vz': 7.112043693659583, 'eci_sun_x': -113149993.411927, 'eci_sun_y': 92613872.07420123, 'eci_sun_z': 40151430.18263137, 'eci_obs_x': 6042.611378274802, 'eci_obs_y': 2041.4405016832857, 'eci_obs_z': 0.0, 'beta_angle': -72.59264563087656}
```

Tested in python 3.7 (due to new manylinux):
```
root@7d623a9bd15b:/pypredict/wheelhouse# python3
Python 3.7.0 (default, Oct 16 2018, 07:10:55) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import predict
>>> tle='''0 LEMUR 1
... 1 40044U 14033AL  23221.74491137  .00002349  00000-0  33527-3 0  9990
... 2 40044  97.6724  33.3927 0055349 242.1156 117.4442 14.76595710491566'''
>>> qth=(0,0,0)
>>> import time
>>> ts=time.time()
>>> predict.quick_predict(tle=tle, qth=qth, ts=ts)[0]
{'norad_id': 40044, 'name': '0 LEMUR 1', 'epoch': 1691726232.0131924, 'latitude': -17.125548721242176, 'longitude': 18.440737662512376, 'azimuth': 134.07376763522498, 'elevation': 0.029358561973790488, 'orbital_velocity': 27081.3574243417, 'footprint': 5556.783744853028, 'altitude': 656.990493629095, 'slant_range': 2960.9341801699593, 'eclipse_depth': -8.078994064946237, 'orbital_phase': 74.53241505128307, 'orbital_model': 'SGP4', 'visibility': b'V', 'sunlit': 1, 'orbit': 49177, 'geostationary': 0, 'has_aos': 1, 'decayed': 0, 'doppler': 1832.0535648101843, 'eci_x': 5363.148895534224, 'eci_y': 4057.3253515128736, 'eci_z': -2059.577980621891, 'eci_vx': 2.3992428089761497, 'eci_vy': 0.49871144502385606, 'eci_vz': 7.112272550593836, 'eci_sun_x': -113149995.28166385, 'eci_sun_y': 92613870.11336055, 'eci_sun_z': 40151429.332538374, 'eci_obs_x': 6042.596991889211, 'eci_obs_y': 2041.4830845197966, 'eci_obs_z': 0.0, 'beta_angle': -72.59264472677555}
```