### PR TITLE
Resolve GCC14 compiler warnings, add python 3.12/3.13 support, remove python 3.7

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Check style with `black`
         uses: psf/black@stable
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -63,6 +63,6 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions pytest
+          pip install tox tox-gh-actions pytest setuptools
       - name: Run tests
         run: tox

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -63,6 +63,6 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions pytest setuptools
+          pip install tox tox-gh-actions pytest
       - name: Run tests
         run: tox

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install: build
 	python3 setup.py install
 
 .PHONY: test
-test: install
+test:
 	pytest
 
 .PHONY: upload

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ sdist := dist/$(NAME)-$(VERSION).tar.gz
 wheels := \
 	dist/$(NAME)-$(VERSION)-cp27-cp27m-$(ARCH).whl \
 	dist/$(NAME)-$(VERSION)-cp27-cp27mu-$(ARCH).whl \
-	dist/$(NAME)-$(VERSION)-cp37-cp37m-$(ARCH).whl \
 	dist/$(NAME)-$(VERSION)-cp38-cp38-$(ARCH).whl \
 	dist/$(NAME)-$(VERSION)-cp39-cp39-$(ARCH).whl \
 	dist/$(NAME)-$(VERSION)-cp310-cp310-$(ARCH).whl \
-	dist/$(NAME)-$(VERSION)-cp311-cp311-$(ARCH).whl
+	dist/$(NAME)-$(VERSION)-cp311-cp311-$(ARCH).whl \
+	dist/$(NAME)-$(VERSION)-cp312-cp312-$(ARCH).whl \
+	dist/$(NAME)-$(VERSION)-cp313-cp313-$(ARCH).whl
 
 .PHONY: help
 help:
@@ -36,7 +37,7 @@ $(wheels): $(src)
 		/io/bin/build-manylinux-wheel.sh 27
 	docker run --user $(shell id -u):$(shell id -g) -v $(shell pwd):/io \
 		quay.io/pypa/manylinux_2_28_x86_64:latest \
-		/io/bin/build-manylinux-wheel.sh 37 38 39 310 311
+		/io/bin/build-manylinux-wheel.sh 38 39 310 311 312 313
 
 .PHONY: sdist
 sdist: $(sdist)

--- a/bin/build-manylinux-wheel.sh
+++ b/bin/build-manylinux-wheel.sh
@@ -18,12 +18,10 @@ fi
 function get-variants() {
     local version="$1"
 
-    if [[ "${version}" = '38' || "${version}" = '39' || "${version}" = '310' || "${version}" = '311' ]] ; then
-        echo /
-    elif [[ "${version}" = '27' ]] ; then
+    if [[ "${version}" = '27' ]] ; then
         echo m mu
     else
-        echo m
+        echo /
     fi
 }
 

--- a/predict.c
+++ b/predict.c
@@ -1110,7 +1110,7 @@ void Deep(int ientry, tle_t * tle, deep_arg_t * deep_arg)
 	g533, gam, sinq, sinzf, sis, sl, sll, sls, stem, temp, temp1, x1,
 	x2, x2li, x2omi, x3, x4, x5, x6, x7, x8, xl, xldot, xmao, xnddt,
 	xndot, xno2, xnodce, xnoi, xomi, xpidot, z1, z11, z12, z13, z2,
-	z21, z22, z23, z3, z31, z32, z33, ze, zf, zm, zmo, zn, zsing,
+	z21, z22, z23, z3, z31, z32, z33, ze, zf, zm, zn, zsing,
 	zsinh, zsini, zcosg, zcosh, zcosi, delt=0, ft=0;
 
 	switch (ientry)
@@ -1164,7 +1164,6 @@ void Deep(int ientry, tle_t * tle, deep_arg_t * deep_arg)
 		  cc=c1ss;
 		  zn=zns;
 		  ze=zes;
-		  zmo=zmos;
 		  xnoi=1/xnq;
 
 		  /* Loop breaks when Solar terms are done a second */
@@ -1269,7 +1268,6 @@ void Deep(int ientry, tle_t * tle, deep_arg_t * deep_arg)
 			zn=znl;
 			cc=c1l;
 			ze=zel;
-			zmo=zmol;
 			SetFlag(LUNAR_TERMS_DONE_FLAG);
 		}
 
@@ -2099,7 +2097,7 @@ double PrimeAngle(double x)
 	return x;
 }
 
-char *SubString(char *string, char start, char end)
+char *SubString(char *string, unsigned start, unsigned end)
 {
 	/* This function returns a substring based on the starting
 	   and ending positions provided.  It is used heavily in
@@ -2127,7 +2125,7 @@ char *SubString(char *string, char start, char end)
 	}
 }
 
-void CopyString(char *source, char *destination, char start, char end)
+void CopyString(char *source, char *destination, unsigned start, unsigned end)
 {
 	/* This function copies elements of the string "source"
 	   bounded by "start" and "end" into the string "destination". */
@@ -2201,7 +2199,7 @@ char KepCheck(const char *line1, const char *line2)
 	return (x ? 0 : 1);
 }
 
-void InternalUpdate(int x)
+void InternalUpdate(void)
 {
 	/* Updates data in TLE structure based on
 	   line1 and line2 stored in structure. */
@@ -2249,7 +2247,7 @@ char *noradEvalue(double value)
 	return output;
 }
 
-void Data2TLE(int x)
+void Data2TLE(void)
 {
 	/* This function converts orbital data held in the numeric
 	   portion of the sat tle structure to ASCII TLE format,
@@ -2424,7 +2422,7 @@ double ReadBearing(char *input)
 
 char ReadTLE(const char *line0, const char *line1, const char *line2)
 {
-	int la, lb, lc;
+	unsigned int la, lb, lc;
 	char error_flags,a,b,c,d;
 
 	la = strnlen(line0,sizeof(sat.name));
@@ -2441,7 +2439,7 @@ char ReadTLE(const char *line0, const char *line1, const char *line2)
 		strncpy(sat.name,line0,sizeof(sat.name)-1);
 		strncpy(sat.line1,line1,sizeof(sat.line1)-1);
 		strncpy(sat.line2,line2,sizeof(sat.line2)-1);
-		InternalUpdate(0);
+		InternalUpdate();
 	}
 
 	return error_flags;
@@ -2555,7 +2553,7 @@ void SaveTLE()
 
 	fd=fopen(tlefile,"w");
 
-	Data2TLE(0);
+	Data2TLE();
 
 	/* Write name, line1, line2 to predict.tle */
 
@@ -2595,11 +2593,10 @@ double CurrentDaynum()
 {
 	/* Read the system clock and return the number
 	   of days since 31Dec79 00:00:00 UTC (daynum 0) */
-	int x;
 	struct timeval tptr;
 	double usecs, seconds;
 
-	x=gettimeofday(&tptr,NULL);
+	gettimeofday(&tptr,NULL);
 
 	usecs=0.000001*(double)tptr.tv_usec;
 	seconds=usecs+(double)tptr.tv_sec;
@@ -2617,7 +2614,7 @@ void FindMoon(double daynum)
 	   http://www.geocities.com/s_perona/ingles/poslun.htm. */
 
 	double	jd, ss, t, t1, t2, t3, d, ff, l1, m, m1, ex, om, l,
-		b, w1, w2, bt, p, lm, h, ra, dec, z, ob, n, e, el,
+		b, w1, w2, bt, p, lm, h, ra, dec, z, ob, n, el,
 		az, teg, th, mm, dv;
 
 	jd=daynum+2444238.5;
@@ -2758,7 +2755,6 @@ void FindMoon(double daynum)
 	/* dec = declination */
 
 	n=qth.stnlat*deg2rad;    /* North latitude of tracking station */
-	e=-qth.stnlong*deg2rad;  /* East longitude of tracking station */
 
 	/* Find siderial time in radians */
 
@@ -2843,7 +2839,7 @@ void FindSun(double daynum)
 	sun_dec=Degrees(solar_rad.y);
 }
 
-void PreCalc(int x)
+void PreCalc(void)
 {
 	/* This function copies TLE data from PREDICT's sat structure
 	   to the SGP4/SDP4's single dimensioned tle structure, and
@@ -3060,7 +3056,7 @@ void Calc()
 	}
 }
 
-char AosHappens(int x)
+char AosHappens(void)
 {
 	/* This function returns a 1 if the satellite pointed to by
 	   "x" can ever rise above the horizon of the ground station. */
@@ -3094,7 +3090,7 @@ char AosHappens(int x)
 	}
 }
 
-char Decayed(int x, double time)
+char Decayed(double time)
 {
 	/* This function returns a 1 if it appears that the
 	   satellite pointed to by 'x' has decayed at the
@@ -3120,7 +3116,7 @@ char Decayed(int x, double time)
 	}
 }
 
-char Geostationary(int x)
+char Geostationary(void)
 {
 	/* This function returns a 1 if the satellite pointed
 	   to by "x" appears to be in a geostationary orbit */
@@ -3142,7 +3138,7 @@ double FindAOS()
 	int iterations = 0;
 	aostime=0.0;
 
-	if (AosHappens(indx) && Geostationary(indx)==0 && Decayed(indx,daynum)==0)
+	if (AosHappens() && Geostationary()==0 && Decayed(daynum)==0)
 	{
 		Calc();
 
@@ -3179,7 +3175,7 @@ double FindLOS()
 {
 	lostime=0.0;
 
-	if (Geostationary(indx)==0 && AosHappens(indx)==1 && Decayed(indx,daynum)==0)
+	if (Geostationary()==0 && AosHappens()==1 && Decayed(daynum)==0)
 	{
 		Calc();
 
@@ -3221,7 +3217,7 @@ double NextAOS()
 
 	aostime=0.0;
 
-	if (AosHappens(indx) && Geostationary(indx)==0 && Decayed(indx,daynum)==0)
+	if (AosHappens() && Geostationary()==0 && Decayed(daynum)==0)
 	{
 		daynum=FindLOS2()+0.014;  /* Move to LOS + 20 minutes */
 	}
@@ -3238,9 +3234,9 @@ double NextAOS()
 //
 int MakeObservation(double obs_time, struct observation * obs) {
     char geostationary=0, aoshappens=0, decayed=0, visibility=0, sunlit;
-    double doppler100=0.0, delay;
+    double doppler100=0.0;
 
-    PreCalc(0);
+    PreCalc();
     indx=0;
 
     if (sat_db.transponders>0)
@@ -3250,9 +3246,9 @@ int MakeObservation(double obs_time, struct observation * obs) {
     }
 
     daynum=obs_time;
-    aoshappens=AosHappens(indx);
-    geostationary=Geostationary(indx);
-    decayed=Decayed(indx,0.0);
+    aoshappens=AosHappens();
+    geostationary=Geostationary();
+    decayed=Decayed(0.0);
 
     //Calcs
     Calc();
@@ -3272,7 +3268,6 @@ int MakeObservation(double obs_time, struct observation * obs) {
     sunlit = sat_sun_status;
 
     doppler100=-100.0e06*((sat_range_rate*1000.0)/299792458.0);
-    delay=1000.0*((1000.0*sat_range)/299792458.0);
 
     //TODO: Seems like FindSun(daynum) should go in here
     FindMoon(daynum);
@@ -3466,6 +3461,7 @@ char load(PyObject *args)
 
 static PyObject* quick_find(PyObject* self, PyObject *args)
 {
+    (void)self;
 	struct observation obs = { 0 };
 
 	if (load(args) != 0 || MakeObservation(daynum, &obs) != 0)
@@ -3482,6 +3478,7 @@ static char quick_find_docs[] =
 
 static PyObject* quick_predict(PyObject* self, PyObject *args)
 {
+    (void)self;
 	double tle_epoch;
 	int lastel=0;
 	char errbuff[100];
@@ -3507,7 +3504,7 @@ static PyObject* quick_predict(PyObject* self, PyObject *args)
 		goto cleanup_and_raise_exception;
 	}
 
-	PreCalc(0);
+	PreCalc();
 	Calc();
 	if (MakeObservation(daynum, &obs) != 0)
 	{
@@ -3515,21 +3512,21 @@ static PyObject* quick_predict(PyObject* self, PyObject *args)
 		goto cleanup_and_raise_exception;
 	}
 
-	if (!AosHappens(0))
+	if (!AosHappens())
 	{
 		sprintf(errbuff, "%lu does not rise above horizon. No AOS.\n", sat.catnum);
 		PyErr_SetString(NoTransitException, errbuff);
 		goto cleanup_and_raise_exception;
 	}
 
-	if (Geostationary(0)!=0)
+	if (Geostationary()!=0)
 	{
 		sprintf(errbuff, "%lu is geostationary.  Does not transit.\n", sat.catnum);
 		PyErr_SetString(PredictException, errbuff);
 		goto cleanup_and_raise_exception;
 	}
 
-	if (Decayed(indx,daynum)!=0)
+	if (Decayed(daynum)!=0)
 	{
 		sprintf(errbuff, "%lu has decayed. Cannot calculate transit.\n", sat.catnum);
 		PyErr_SetString(PredictException, errbuff);

--- a/predict.c
+++ b/predict.c
@@ -2071,7 +2071,7 @@ void Calculate_RADec(double time, vector_t *pos, vector_t *vel, geodetic_t *geod
 
 /* .... SGP4/SDP4 functions end .... */
 
-time_t CurrentTime()
+time_t CurrentTime(void)
 {
 	return time(NULL);
 }
@@ -2461,7 +2461,7 @@ char ReadQTH(double lat, double lon, long alt)
 }
 
 
-char ReadQTHFile()
+char ReadQTHFile(void)
 {
 	FILE *fd;
 
@@ -2529,7 +2529,7 @@ char CopyFile(char *source, char *destination)
 	return error;
 }
 
-void SaveQTH()
+void SaveQTH(void)
 {
 	/* This function saves QTH data to the QTH data file. */
 
@@ -2545,7 +2545,7 @@ void SaveQTH()
 	fclose(fd);
 }
 
-void SaveTLE()
+void SaveTLE(void)
 {
 	FILE *fd;
 
@@ -2589,7 +2589,7 @@ long DayNum(int m, int d, int y)
 	return dn;
 }
 
-double CurrentDaynum()
+double CurrentDaynum(void)
 {
 	/* Read the system clock and return the number
 	   of days since 31Dec79 00:00:00 UTC (daynum 0) */
@@ -2884,7 +2884,7 @@ void PreCalc(void)
 	select_ephemeris(&tle);
 }
 
-void Calc()
+void Calc(void)
 {
 	/* This is the stuff we need to do repetitively while tracking. */
 
@@ -3131,7 +3131,7 @@ char Geostationary(void)
 	}
 }
 
-double FindAOS()
+double FindAOS(void)
 {
 	/* This function finds and returns the time of AOS (aostime). */
 
@@ -3171,7 +3171,7 @@ double FindAOS()
 	return aostime;
 }
 
-double FindLOS()
+double FindLOS(void)
 {
 	lostime=0.0;
 
@@ -3195,7 +3195,7 @@ double FindLOS()
 	return lostime;
 }
 
-double FindLOS2()
+double FindLOS2(void)
 {
 	/* This function steps through the pass to find LOS.
 	   FindLOS() is called to "fine tune" and return the result. */
@@ -3210,7 +3210,7 @@ double FindLOS2()
 	return(FindLOS());
 }
 
-double NextAOS()
+double NextAOS(void)
 {
 	/* This function finds and returns the time of the next
 	   AOS for a satellite that is currently in range. */

--- a/predict.c
+++ b/predict.c
@@ -2164,7 +2164,7 @@ char *Abbreviate(char *string, int n)
 	return temp;
 }
 
-char KepCheck(char *line1, char *line2)
+char KepCheck(const char *line1, const char *line2)
 {
 	/* This function scans line 1 and line 2 of a NASA 2-Line element
 	   set and returns a 1 if the element set appears to be valid or
@@ -2422,7 +2422,7 @@ double ReadBearing(char *input)
 	return bearing;
 }
 
-char ReadTLE(char *line0, char *line1, char *line2)
+char ReadTLE(const char *line0, const char *line1, const char *line2)
 {
 	int la, lb, lc;
 	char error_flags,a,b,c,d;
@@ -3285,7 +3285,7 @@ int MakeObservation(double obs_time, struct observation * obs) {
     //printw(17+bshift,1,"-------------   -------------   -------------   ------------      ------------");
 
     obs->norad_id = sat.catnum;
-    strncpy(&(obs->name), &(sat.name), sizeof(obs->name));
+    strncpy(obs->name, sat.name, sizeof(obs->name));
     obs->epoch = (daynum+3651.0)*(86400.0); //See daynum=((start/86400.0)-3651.0);
     obs->latitude = sat_lat;
     obs->longitude = sat_lon;
@@ -3297,7 +3297,7 @@ int MakeObservation(double obs_time, struct observation * obs) {
     obs->slant_range = sat_range;
     obs->eclipse_depth = eclipse_depth/deg2rad;
     obs->orbital_phase = 256.0*(phase/twopi);
-    strncpy(&(obs->orbital_model), &(ephem), sizeof(obs->orbital_model));
+    strncpy(obs->orbital_model, ephem, sizeof(obs->orbital_model));
     obs->visibility = visibility;
     obs->sunlit = sunlit;
     obs->orbit = rv;
@@ -3322,7 +3322,7 @@ int MakeObservation(double obs_time, struct observation * obs) {
 }
 
 void PrintObservation(struct observation * obs) {
-    printf("NORAD_ID        %d\n", obs->norad_id);
+    printf("NORAD_ID        %ld\n", obs->norad_id);
     printf("Name            %s\n", obs->name);
     printf("Date(epoch)     %f\n", obs->epoch);
     printf("Latitude(N)     %f\n", obs->latitude);

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pypredict",
-    version="1.7.2",
+    version="1.7.3",
     author="Jesse Trutna",
     author_email="jesse@spire.com",
     maintainer="Spire Global Inc",
@@ -26,5 +26,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pypredict",
-    version="1.7.3",
+    version="1.8.0",
     author="Jesse Trutna",
     author_email="jesse@spire.com",
     maintainer="Spire Global Inc",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py38,py39,py310,py311
+envlist = py27,py38,py39,py310,py311,py312,py313
 
 [testenv]
 deps = pytest
@@ -15,3 +15,5 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ allowlist_externals = make
 [gh-actions]
 python =
     2.7: py27
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
Addresses the warnings in #69, although slightly differently, not by changing the cast, but instead not trying to dereference what is already a pointer to the char array.

Then when testing, found several other warnings when compiling with the latest GCC14, GCC15 and clang19 with -Wall and -Wextra - so addressed those too, mostly unused variables.

These changes should make no difference to the functionality of the code, but avoids compilation issues with newer setups.

Also adds support for Python 3.12 and 3.13, and removes support for Python 3.7